### PR TITLE
feat: better toggling of stdout or otlp tracing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-tracing-utils"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "console-subscriber",

--- a/packages/opentelemetry-tracing-utils/CHANGELOG.md
+++ b/packages/opentelemetry-tracing-utils/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+- Support for the `OTEL_TRACES_EXPORTER` env var to control whether to use OTLP or not.
+
 ## [0.6.0] - 2025-04-21
 
 ### Changed

--- a/packages/opentelemetry-tracing-utils/Cargo.toml
+++ b/packages/opentelemetry-tracing-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-tracing-utils"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license = "MIT OR Apache-2.0"
 authors.workspace = true


### PR DESCRIPTION
Allow using the OpenTelemetry standard env var of OTEL_TRACES_EXPORTER as well.